### PR TITLE
Fixed the embed fragments

### DIFF
--- a/src/fragments.js
+++ b/src/fragments.js
@@ -78,7 +78,7 @@
 
     Embed.prototype = {
         asHtml: function () {
-            return "<span>" + this.value + "</span>";
+            return this.oembed.html;
         }
     };
 


### PR DESCRIPTION
From the advice of prismic.io user Philip Hsiao.

The cause: we implemented the embeds in structured text fragments, but forgot to bind it to the "standalone" embed fragments, which were still raising an error, while the code was already done and working.
