### PR TITLE
Remove the append of #json in the authorization request

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -48,7 +48,7 @@
                 };
 
                 // Open the XHR
-                xhr.open('GET', url + '#json', true);
+                xhr.open('GET', url, true);
 
                 // Json request
                 xhr.setRequestHeader('Accept', 'application/json');


### PR DESCRIPTION
Actually to resolve #18 you just need to remove the append of the #json to the URL. It works flawless in other browsers as well.

You are already setting the Accept request header to "application/json" so I guess there's no need to append the #json to the Request
