### PR TITLE
Return group.value rather than fragment itself

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -794,7 +794,7 @@
             var fragment = this.get(fragment);
 
             if (fragment instanceof Global.Prismic.Fragments.Group) {
-                return fragment;
+                return fragment.value;
             }
         },
 


### PR DESCRIPTION
Being consistent with other methods and being different than `getFragment`.
