### PR TITLE
asHtml() breaks when document contains list-item in content

### DIFF
--- a/src/fragments.js
+++ b/src/fragments.js
@@ -520,11 +520,11 @@
                     blockGroup = new BlockGroup(block.type, []);
                     blockGroups.push(blockGroup);
                 }
-                else if (blockGroup && blockGroup.tag != block.type) { // it's a new type
+                else if (!blockGroup || blockGroup.tag != block.type) { // it's a new type or no BlockGroup was set so far
                     blockGroup = new BlockGroup(block.type, []);
                     blockGroups.push(blockGroup);
                 }
-                // else: it's the same type as before, no touching group
+                // else: it's the same type as before, no touching blockGroup
 
                 blockGroup.blocks.push(block);
             };


### PR DESCRIPTION
I found a bug today in the fragments parser when attempting to use asHtml() to render my page today. Removing the bullet points in the Prismic.io editor fixed the problem, so it appears to be specific to list-items.

My api with post in question is: 
https://mobicorp.prismic.io/api/documents/search?ref=U21dGAEAADEAo8sa&q=%5B%5B%3Ad+%3D+at(document.id%2C+%22U2ucHgEAAC4ALRo1%22)+%5D%5D

The error printed in my terminal:
/Users/jmelvin/Development/mobicorpcom/node_modules/prismic.io/dist/prismic.io.js:1380 
blockGroup.blocks.push(block); 
^ 
TypeError: Cannot read property 'blocks' of undefined 
at Object.StructuredTextAsHtml (/Users/jmelvin/Development/mobicorpcom/node_modules/prismic.io/dist/prismic.io.js:1380:27)
at Object.StructuredText.asHtml (/Users/jmelvin/Development/mobicorpcom/node_modules/prismic.io/dist/prismic.io.js:1346:41)
at /Users/jmelvin/Development/mobicorpcom/server/routes/knowledge-center.js:235:87 
at /Users/jmelvin/Development/mobicorpcom/node_modules/prismic.io/dist/prismic.io.js:452:17 
at IncomingMessage.<anonymous> (/Users/jmelvin/Development/mobicorpcom/node_modules/prismic.io/dist/prismic.io.js:106:31) <br> at IncomingMessage.EventEmitter.emit (events.js:117:20) <br> at _stream_readable.js:920:16 <br> at process._tickCallback (node.js:415:13)</anonymous>
