### PR TITLE
Zero-length and negative spans are now removed in submit()

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -498,6 +498,25 @@
                         fragments[doc.type + '.' + field] = doc.data[doc.type][field];
                     }
 
+                    /* Removing incorrect spans from StructuredText fragments */
+                    // This should be removed when the issue is fixed in the API
+                    for(var fragmentKey in fragments) {
+                        var fragment = fragments[fragmentKey];
+                        if (fragment.type === 'StructuredText') {
+                            for (var blockKey in fragment.value) {
+                                var block = fragment.value[blockKey];
+                                var newSpanArray = [];
+                                for (var spanKey in block.spans) {
+                                    var span = block.spans[spanKey];
+                                    if (span.start < span.end) {
+                                        newSpanArray.push(span);
+                                    }
+                                }
+                                block['spans'] = newSpanArray;
+                            }
+                        }
+                    }
+
                     return new Doc(
                         doc.id,
                         doc.type,

--- a/src/fragments.js
+++ b/src/fragments.js
@@ -728,15 +728,6 @@
         var cursor = 0;
         var html = [];
 
-        /* checking the spans are following each other, or else not doing anything */
-        spans.forEach(function(span){
-            if (span.end < span.start) return text;
-            if (span.start < cursor) return text;
-            cursor = span.end;
-        });
-
-        cursor = 0;
-
         spans.forEach(function(span){
             textBits.push(text.substring(0, span.start-cursor));
             text = text.substring(span.start-cursor);


### PR DESCRIPTION
There is a bug in the API that returns wrong spans in structured text fragments, with start == end, or start > end, like that:

```
spans: [
  {
    start: 43,
    end: 43,
    type: "strong"
  },
  {
    start: 102,
    end: 43,
    type: "strong"
  }
]
```

Up till now, the kit was working around the bug by discarding those spans in `asHtml()`; but this only works if `asHtml()` is what you want to do with your structured text. For any other manipulation, you still have those spans hanging around.
This PR removes the workaround in `asHtml` that passively discards those spans, and introduces another workaround, in `submit()` this time, that actively suppresses those spans before documents are returned. This effectively make all structured text fragments clean from wrong spans, before any manipulation gets done.
