### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "prismic.io",
+  "version": "1.1.4",
+  "homepage": "https://github.com/prismicio/javascript-kit",
+  "description": "JavaScript development kit for prismic.io",
+  "main": "./dist/prismic.io.min.js"
+}


### PR DESCRIPTION
Bower.json and especially the "main"-attribute is required by tools such as https://github.com/taptapship/wiredep
