### PR TITLE
Catch possible exception in linkResolver

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -324,10 +324,17 @@
                         callback(null, defaultUrl, xhr);
                     } else {
                         api.form("everything").query(Predicates.at("document.id", mainDocumentId)).ref(token).submit(function(err, response) {
-                            if (response.results.length === 0) {
-                                callback(null, defaultUrl, xhr);
-                            } else {
-                                callback(null, linkResolver(response.results[0]), xhr);
+                            if (err) {
+                                callback(err);
+                            }
+                            try {
+                                if (response.results.length === 0) {
+                                    callback(null, defaultUrl, xhr);
+                                } else {
+                                    callback(null, linkResolver(response.results[0]), xhr);
+                                }
+                            } catch (e) {
+                                callback(e);
                             }
                         });
                     }


### PR DESCRIPTION
We experienced an issue with previewSession. When linkResolver fails for some random reason errors are not propagated through the callback
