### PR TITLE
Export Embed fragment in fragments.js

### DIFF
--- a/src/fragments.js
+++ b/src/fragments.js
@@ -1144,6 +1144,7 @@
     }
 
     Global.Prismic.Fragments = {
+        Embed: Embed,
         Image: ImageEl,
         ImageView: ImageView,
         Text: Text,


### PR DESCRIPTION
Embed is the only fragment type that isn't exported in the Global.Prismic.Fragments object.

- Add Embed to exports

