### PR TITLE
Fix "scripts" typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "http://github.com/prismicio/javascript-kit.git"
   },
   "main": "dist/prismic.io",
-  "scripts:": {
+  "scripts": {
     "test": "gulp test"
   }
 }


### PR DESCRIPTION
The typo prevents `npm` from finding the `test` script when running `npm test`.