### PR TITLE
Cache JSON documents instead of Response Object

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -410,7 +410,7 @@ Api.prototype = {
     var cache = this.apiCache;
     cache.get(cacheKey, function (err, value) {
       if (err || value) {
-        callback(err, value);
+        callback(err, api.response(value));
         return;
       }
       api.requestHandler(url, function (err, documents, xhr, ttl) {
@@ -418,25 +418,32 @@ Api.prototype = {
           callback(err, null, xhr);
           return;
         }
-        var results = documents.results.map(parseDoc);
-        var response = new Response(
-          documents.page,
-          documents.results_per_page,
-          documents.results_size,
-          documents.total_results_size,
-          documents.total_pages,
-          documents.next_page,
-          documents.prev_page,
-          results || []);
+
         if (ttl) {
-          cache.set(cacheKey, response, ttl, function (err) {
-            callback(err, response);
+          cache.set(cacheKey, documents, ttl, function (err) {
+            callback(err, api.response(documents));
           });
         } else {
-          callback(null, response);
+          callback(null, api.response(documents));
         }
       });
     });
+  },
+
+  /**
+   * JSON documents to Response object
+   */
+  response: function(documents){
+    var results = documents.results.map(parseDoc);
+    return new Response(
+      documents.page,
+      documents.results_per_page,
+      documents.results_size,
+      documents.total_results_size,
+      documents.total_pages,
+      documents.next_page,
+      documents.prev_page,
+      results || []);
   }
 
 };


### PR DESCRIPTION
This will be useful for custom cache implementation, which may need
serialize/deserialize object.