### PR TITLE
fix(api): pass correct opts to new Api

### DIFF
--- a/lib/prismic.js
+++ b/lib/prismic.js
@@ -38,10 +38,10 @@ function getApi(url, options) {
   } else if (typeof arguments[1] == 'string') {
     // Legacy (2) the second argument is the accessToken
     options = {
-      "maybeAccessToken": arguments[1],
-      "maybeRequestHandler": arguments[2],
-      "maybeApiCache": arguments[3],
-      "maybeApiDataTTL": arguments[4]
+      "accessToken": arguments[1],
+      "requestHandler": arguments[2],
+      "apiCache": arguments[3],
+      "apiDataTTL": arguments[4]
     };
   }
   var api = new Api(url, options || {});


### PR DESCRIPTION
This fixes an issue when upgrading from v2 to v3 where the access token and other options were not passed to the Api constructor function properly. The opts in legacy 2 branch are using the legacy names as keys. maybe... is not used in the Api constructor function. This changes those keys to the correct keys used in the Api constructor function.