### PR TITLE
fix(timestamp): check timestamp input to avoid error

### DIFF
--- a/lib/fragments.js
+++ b/lib/fragments.js
@@ -443,8 +443,13 @@ function Timestamp(data) {
    * @description the Date value of the fragment (as a regular JS Date object)
    */
   // Adding ":" in the locale if needed, so JS considers it ISO8601-compliant
-  var correctIso8601Date = (data.length == 24) ? data.substring(0, 22) + ':' + data.substring(22, 24) : data;
-  this.value = new Date(correctIso8601Date);
+  if (data) {
+    var correctIso8601Date = (data.length == 24) ? data.substring(0, 22) + ':' + data.substring(22, 24) : data;
+    this.value = new Date(correctIso8601Date);
+  }
+  else {
+    this.value = null;
+  }
 }
 
 Timestamp.prototype = {

--- a/test/unit.js
+++ b/test/unit.js
@@ -47,6 +47,19 @@ describe("Unit tests", function() {
     assert.equal(html, fragment.asHtml());
   });
 
+  it('should init Timestamp without value', function () {
+    assert.doesNotThrow(function() {
+      var field = Prismic.Fragments.initField({"type" : "Timestamp", "value" : null });
+      assert.equal(field.value, null);
+    });
+  });
+
+  it('should init Timestamp with valid date string', function () {
+    var dateString = '1970-11-23T00:00:00.000';
+    var field = Prismic.Fragments.initField({"type" : "Timestamp", "value" : dateString });
+    assert.deepEqual(field.value, new Date(dateString));
+  });
+
 });
 
 describe("HTML content", function() {


### PR DESCRIPTION
We have an issue where some timestamps are empty which crash the server. I think this is because we added a new timestamp field while we already have some documents.

The timestamp now sets to 1970 even if null is passed. I'm not too sure what the desired behaviour is and I do not want to create regressions.