### PR TITLE
Update i18n document structure

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -570,7 +570,8 @@ var parseDoc = function(json) {
     slugs,
     json.first_publication_date,
     json.last_publication_date,
-    json.i18n,
+    json.lang,
+    json.alternate_languages,
     fragments
   );
 };
@@ -699,10 +700,10 @@ SearchForm.prototype = {
   /**
    * Sets the language to query for this SearchForm. This is an optional method.
    *
-   * @param {string} fields - The list of fields, array or comma separated string
+   * @param {string} fields - The language code
    * @returns {SearchForm} - The SearchForm itself
    */
-  language: function(fields) {
+  lang: function(fields) {
     return this.set("lang", fields);
   },
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -337,7 +337,7 @@ Api.prototype = {
       options = undefined;
     }
     var opts = {};
-    for (var key in Object.keys(options || {})) {
+    for (var key in (options || {})) {
       opts[key] = options[key];
     }
     opts.page = 1;

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -506,7 +506,7 @@ WithFragments.prototype = {
  * @global
  * @alias Doc
  */
-function Document(id, uid, type, href, tags, slugs, firstPublicationDate, lastPublicationDate, i18n, data) {
+function Document(id, uid, type, href, tags, slugs, firstPublicationDate, lastPublicationDate, lang, alternateLanguages, data) {
   /**
    * The ID of the document
    * @type {string}
@@ -555,9 +555,13 @@ function Document(id, uid, type, href, tags, slugs, firstPublicationDate, lastPu
    */
   this.lastPublicationDate = lastPublicationDate ? new Date(lastPublicationDate) : null;
   /**
-   * The internationalization data of the document
+   * The language code of the document
    */
-  this.i18n = i18n ? i18n : null;
+  this.lang = lang ? lang : null;
+  /**
+   * The alternate language versions of the document
+   */
+  this.alternateLanguages = alternateLanguages ? alternateLanguages : [];
   /**
    * Fragments, converted to business objects
    */

--- a/lib/fragments.js
+++ b/lib/fragments.js
@@ -68,6 +68,11 @@ function DocumentLink(data) {
    * @description the linked document type
    */
   this.type = data.document.type;
+  /**
+   * @field
+   * @description the linked document language
+   */
+  this.lang = data.document.lang;
 
   var fragmentsData = {};
   if (data.document.data) {


### PR DESCRIPTION
Update the kit to handle the new i18n API structure.
Rename "language" function to "lang" to match the option's name.
Fix queryFirst issue when passing options.
Add the language to Document Links.