### PR TITLE
Add default wildcard lang value to query helper functions

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -359,6 +359,8 @@ Api.prototype = {
    * @param {function} callback(err, doc)
    */
   getByID: function(id, options, callback) {
+    options = options || {};
+    if(!options.lang) options.lang = '*';
     return this.queryFirst(Predicates.at('document.id', id), options, callback);
   },
 
@@ -369,6 +371,8 @@ Api.prototype = {
    * @param {function} callback(err, response)
    */
   getByIDs: function(ids, options, callback) {
+    options = options || {};
+    if(!options.lang) options.lang = '*';
     return this.query(['in', 'document.id', ids], options, callback);
   },
 
@@ -380,6 +384,8 @@ Api.prototype = {
    * @param {function} callback(err, response)
    */
   getByUID: function(type, uid, options, callback) {
+    options = options || {};
+    if(!options.lang) options.lang = '*';
     return this.queryFirst(Predicates.at('my.'+type+'.uid', uid), options, callback);
   },
 
@@ -445,7 +451,7 @@ Api.prototype = {
           if (!mainDocumentId) {
             cb(null, defaultUrl, xhr);
           } else {
-            api.form("everything").query(Predicates.at("document.id", mainDocumentId)).ref(token).submit(function(err, response) {
+            api.form("everything").query(Predicates.at("document.id", mainDocumentId)).ref(token).lang('*').submit(function(err, response) {
               if (err) {
                 cb(err);
               }


### PR DESCRIPTION
Adds a default wildcard lang value to the following functions:
- getByID
- getByIDs
- getByUID
- previewSession