### PR TITLE
Fix asHtml and asText-methods for CompositeSlice-fragments

### DIFF
--- a/lib/fragments.js
+++ b/lib/fragments.js
@@ -1088,7 +1088,9 @@ CompositeSlice.prototype = {
 
     var nonRepeatHtml = "";
     for (var field in this.nonRepeat) {
-      nonRepeatHtml += field.asHtml(linkResolver);
+      if (this.nonRepeat.hasOwnProperty(field)) {
+        nonRepeatHtml += this.nonRepeat[field].asHtml(linkResolver);
+      } 
     }
 
     return '<div data-slicetype="' + this.sliceType + '" class="' + classes.join(' ') + '">' +
@@ -1105,7 +1107,9 @@ CompositeSlice.prototype = {
   asText: function(linkResolver) {
     var text = "";
     for (var field in this.nonRepeat) {
-      text += field.asText(linkResolver);
+      if (this.nonRepeat.hasOwnProperty(field)) {
+        text += this.nonRepeat[field].asText(linkResolver);
+      }
     }
     text += this.repeat.asText(linkResolver);
     return text;


### PR DESCRIPTION
This PR fixes `asHtml` and `asText` methods for CompositeSlice-fragments.

`asHtml` and `asText` were being called on the object keys instead of the object values, which resulted in `field.asHtml is not a function` error.  In addition the assignments are wrapped in `hasOwnProperty` checks to prevent `asHtml` and `asText` being called on possible `prototype` methods that might not have `asHtml` and/or `asText`.