### PR TITLE
Check if the key exists and its value is not null

### DIFF
--- a/lib/fragments.js
+++ b/lib/fragments.js
@@ -1316,7 +1316,7 @@ function initField(field) {
 function parseFragments(json) {
   var result = {};
   for (var key in json) {
-    if (json.hasOwnProperty(key)) {
+    if (json[key]) {
       if (Array.isArray(json[key])) {
         result[key] = json[key].map(function (fragment) {
           return initField(fragment);


### PR DESCRIPTION
This PR contains minor fix related to issue #152. 

If you have removed content through the editor and for example the textfield is empty the there will be null values for that key in the json object. I changed to conditional logic to check that the key exits and the value for that isn't null.