### PR TITLE
Use Array.isArray to check if query is an array

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -655,7 +655,7 @@ SearchForm.prototype = {
       return this.set("q", query);
     } else {
       var predicates;
-      if (query.constructor === Array && query.length > 0 && query[0].constructor === Array) {
+      if (Array.isArray(query) && query.length > 0 && Array.isArray(query[0])) {
         predicates = query;
       } else {
         predicates = [].slice.apply(arguments); // Convert to a real JS array


### PR DESCRIPTION
Running this in node, I was hitting an error. I was getting typeof `Object` instead of array. 

This fix is only supported in IE 9 and above (not sure if you all are supporting IE 8).

If IE 8 is required, we can switch this to:

`Object.prototype.toString.call(query) == '[object Array]'`